### PR TITLE
Modifications for multi testcases handling, fixing some bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "postinstall": "husky install",
+    "postinstall": "node -e \"if (require('fs').existsSync('.git')){process.exit(1)}\" || husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable",
     "build": "npm run build:cjs && npm run build:esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azuredevops-test-reporter",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Azure DevOps Test Reporter to inject result of automatic test run in Azure DevOps TestPlan",
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,13 +46,14 @@ export class AzureTestPlanReporter implements IAzureTestPlanReporter {
     this._azureClient = await createConnection(this._config)
   }
 
-  public async starTestRun(): Promise<TestRun> {
+  public async starTestRun(testResultIds?: number[]): Promise<TestRun> {
     const testRun = await createTestRun(
       this._azureClient,
       this._axiosClient,
-      this._config
+      this._config,
+      testResultIds
     )
-    setInProgressRun(this._azureClient, this._config, testRun.id)
+    //await setInProgressRun(this._azureClient, this._config, testRun.id)
     this.testRunId = testRun.id
     return testRun
   }

--- a/src/interfaces/IAzureConfig.ts
+++ b/src/interfaces/IAzureConfig.ts
@@ -6,4 +6,5 @@ export interface IAzureConfig {
   suiteId: number
   runName: string
   caseIdRegex?: string
+  configurationName?: string
 }

--- a/src/schema-validation/index.ts
+++ b/src/schema-validation/index.ts
@@ -30,4 +30,8 @@ export const azureConfig = new Schema({
     type: String,
     required: false,
   },
+  configurationName: {
+    type: String,
+    required: false,
+  },
 })

--- a/src/services/azure/testResults.ts
+++ b/src/services/azure/testResults.ts
@@ -25,8 +25,18 @@ export async function setTestResult(
 
   const updatedResult = testsInRun.filter((test) => {
     if (test.testCase?.id === testResult.testCaseId) {
-      test.outcome = testResult.result
-      test.comment = testResult.message
+      // Failed result is dominant and will not be overwritten by passed result of other test
+      if (test.outcome !== 'Failed') {
+        test.outcome = testResult.result
+      }
+
+      // Adds result of failed test to comment
+      if (testResult.result === 'Failed') {
+        test.comment = `${test.comment !== undefined ? test.comment : ''}${
+          testResult.message
+        } `.substring(0, 1000)
+      }
+
       test.state = 'Completed'
       return test
     }

--- a/src/services/azure/testRun.ts
+++ b/src/services/azure/testRun.ts
@@ -8,14 +8,16 @@ import { AxiosInstance } from 'axios'
 export async function createTestRun(
   azureClient: ITestApi,
   axiosClient: AxiosInstance,
-  azureConfig: IAzureConfig
+  azureConfig: IAzureConfig,
+  testResultIds?: number[]
 ): Promise<TestInterfaces.TestRun> {
   const plan = {
     id: `${azureConfig.planId}`,
     name: azureConfig.runName,
   }
 
-  const pointIds = await getPoints(axiosClient, azureConfig)
+  let pointIds = await getPoints(axiosClient, azureConfig, testResultIds)
+
   const testRunModel = new RunCreateModel(azureConfig.runName, plan, pointIds)
 
   return azureClient.createTestRun(testRunModel, azureConfig.projectId)


### PR DESCRIPTION
- Optional parameter added to function createTestRun: Reduces run to only tests in parameter array (fix for all testcases staying 'InProgress' https://github.com/gianlucamangiapelo/wdio-azure-devops-service/issues/8, but needs adaptions in service as well )
- Added continuiation token in testCasesPoints: with old function maximum 200 testcases were extracted
- Changed version from wrong 0.0.6 to last git version(0.0.8) plus 1 =0.0.9
- Followin needed for multiple automated tests matching on one manual test:
-- Set failed result to dominant result (failed+passed=> failed)
-- Testcase comment also included and adapted for multiple testcases
